### PR TITLE
Fix for mixed content warning on https sites

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2,7 +2,7 @@
    Includes
    ========================================================================== */
 
-@import url('http://fonts.googleapis.com/css?family=Fira+Sans:400,500,700|Cardo:400,400italic,700');
+@import url('//fonts.googleapis.com/css?family=Fira+Sans:400,500,700|Cardo:400,400italic,700');
 @import url('normalize.css');
 @import url('icons.css');
 @import url('highlight.css');


### PR DESCRIPTION
Updated styles.css to use `//google/fonts/url` instead of `http://google/fonts/url` for the fonts import.