### PR TITLE
Make sure wide images are centered

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -360,7 +360,7 @@ img[src$="#full"] {
   }
 
   .kg-image {
-    margin: 0;
+    margin: 0 auto;
   }
 
   figcaption {


### PR DESCRIPTION
Whenever the image width is smaller than container's width, the image would be alligned to the left. This fix prevent such behavior.