### PR TITLE
Make sure there's no additional vertical margin in post-content

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -1027,6 +1027,14 @@ img[src$="#full"] {
     min-width: 100%;
     max-width: 100%;
     box-sizing: border-box;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+
+	&:first-child {
+		margin-top: 0;
+	}
 }
 .post-content a {
 	border-bottom: 1px solid $primary-color;


### PR DESCRIPTION
There's at least a few cases where post components create additional margin on top or bottom of post-content:

- Full wide image adds top margin
- Any image adds bottom margin
- Paragraphs add bottom margin

This fix makes sure there's no additional vertical margin, as it breaks consistency between posts. `post-content` and `post-info` already have it's paddings and margins respectively.