### PR TITLE
Remove forced scrollbar from code blocks

### DIFF
--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -265,7 +265,6 @@ pre code, pre tt {
 	top: auto;
 	margin: -1.334em -1.334em -1.334em 1.334em;
 	padding: 1.334em;
-	overflow: scroll;
 	font-size: 0.75em;
 	line-height: 2em;
 	white-space: pre;


### PR DESCRIPTION
Not sure why it was there in the first place. It clutters the view, especially when the code snipped is short, compare these examples:

![example](https://user-images.githubusercontent.com/11166786/44265449-d7561500-a226-11e8-851f-5252665c205f.png)

Horizontal scrollbar will appear as needed. I don't think there's a need for vertical one.