### PR TITLE
Changed footer URLs to HTTPS

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -26,8 +26,8 @@
 		<footer id="footer">
 			<div class="inner">
 				<section class="credits">
-					<span class="credits-theme">{{t "Theme" }} <a href="https://github.com/zutrinken/attila">Attila</a> {{t "by"}} <a href="http://zutrinken.com" rel="nofollow">zutrinken</a></span>
-					<span class="credits-software">{{t "Published with"}} <a href="http://ghost.org">Ghost</a></span>
+					<span class="credits-theme">{{t "Theme" }} <a href="https://github.com/zutrinken/attila">Attila</a> {{t "by"}} <a href="https://zutrinken.com" rel="nofollow">zutrinken</a></span>
+					<span class="credits-software">{{t "Published with"}} <a href="https://ghost.org">Ghost</a></span>
 				</section>
 			</div>
 		</footer>


### PR DESCRIPTION
Minor adjustment, just switches the href's in the footer to be https://. Should get rid of some browser complaints about attempting to load non-https content. 