### PR TITLE
defining the number of lines unselectable

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -119,6 +119,9 @@ jQuery(function($) {
 				var code = $(this);
 				var lines = code.html().split(/\n/).length;
 				var numbers = [];
+				if (lines > 1) {
+					lines++;
+				}
 				for (i = 1; i < lines; i++) {
 					numbers += '<span class="line">' + i + '</span>';
 				}

--- a/src/sass/style.scss
+++ b/src/sass/style.scss
@@ -258,6 +258,7 @@ pre .lines .line {
 	display: block;
 	padding-right: 0.33333em;
     color: $color-blue-30;
+	user-select: none;
 }
 
 pre code, pre tt {


### PR DESCRIPTION
When we add code in the publication, the number of lines of code is selectable. I believe that making it unselectable can make usability better when someone tries to copy the code.