### PR TITLE
fix(local-fr): edit 'sur' by 'le' for 'on' translation

### DIFF
--- a/locales/fr.json
+++ b/locales/fr.json
@@ -15,7 +15,7 @@
     "Website": "Site",
     "Your email address": "Votre adresse email",
     "By": "Par",
-    "on ": "sur ",
+    "on ": "le",
     "No Posts": "Pas d'article",
     "% Post": "% Article",
     "% Posts": "% Articles",


### PR DESCRIPTION
'on' is translated 'le' instead of 'sur' in french designating a date. (src : https://francais.lingolia.com/fr/vocabulaire/nombres-date-et-heure/la-date - "Pour donner la date complète, nous ajoutons l’article le devant la date.").