### PR TITLE
Add some missing german translations for member buttons & texts

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -36,5 +36,7 @@
     "Footer": "Fußzeile",
     "Pagination": "Seiten",
     "Next post": "Nächster Beitrag",
-    "Previous post": "Vorheriger Beitrag"
+    "Previous post": "Vorheriger Beitrag",
+    "Sign in": "Anmelden",
+    "Sign up": "Mitglied werden"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,7 +1,7 @@
 {
     "Logo": "Logo",
     "Close": "Schließen",
-    "Get the latest posts delivered right to your inbox.": "Empfange die neuesten Posts direkt in deinem Posteingang.",
+    "Get the latest posts delivered right to your inbox.": "Empfange die neuesten Beiträge direkt in deinem Posteingang.",
     "Home": "Startseite",
     "Menu": "Menü",
     "Newer Posts": "Neuere Beiträge",
@@ -38,5 +38,11 @@
     "Next post": "Nächster Beitrag",
     "Previous post": "Vorheriger Beitrag",
     "Sign in": "Anmelden",
-    "Sign up": "Mitglied werden"
+    "Sign up": "Mitglied werden",
+    "This post is for paying subscribers only": "Dieser Beitrag ist nur für zahlende Mitglieder",
+    "This post is for subscribers only": "Dieser Beitrag ist nur für Mitglieder",
+    "This page is for paying subscribers only": "Diese Seite ist nur für zahlende Mitglieder",
+    "This page is for subscribers only": "Diese Seite ist nur für Mitglieder",
+    "Already have an account?": "Hast du schon einen Account?",
+    "Don't have an account yet?": "Du hast noch keinen Account?",
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -37,13 +37,7 @@
     "Pagination": "Seiten",
     "Next post": "Nächster Beitrag",
     "Previous post": "Vorheriger Beitrag",
-    "Sign in": "Anmelden",
-    "Sign up": "Mitglied werden",
-    "This post is for paying subscribers only": "Dieser Beitrag ist nur für zahlende Mitglieder",
-    "This post is for subscribers only": "Dieser Beitrag ist nur für Mitglieder",
-    "This page is for paying subscribers only": "Diese Seite ist nur für zahlende Mitglieder",
-    "This page is for subscribers only": "Diese Seite ist nur für Mitglieder",
-    "Already have an account?": "Hast du schon einen Account?",
-    "Don't have an account yet?": "Du hast noch keinen Account?",
-    "Subscribe now": "Jetzt Mitglied werden"
+    "Sign in": "Einloggen",
+    "Sign up": "Registrieren",
+    "Subscribe now": "Jetzt registrieren"
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -45,4 +45,5 @@
     "This page is for subscribers only": "Diese Seite ist nur für Mitglieder",
     "Already have an account?": "Hast du schon einen Account?",
     "Don't have an account yet?": "Du hast noch keinen Account?",
+    "Subscribe now": "Jetzt Mitglied werden"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,5 +36,8 @@
     "Footer": "Footer",
     "Pagination": "Pagination",
     "Next post": "Next post",
-    "Previous post": "Previous post"
+    "Previous post": "Previous post",
+    "Sign in": "Sign in",
+    "Sign up": "Sign up",
+    "Subscribe now": "Subscribe now"
 }


### PR DESCRIPTION
I added some missing translations for member features.

I also adjusted one translation that mentioned "Posts" instead of "Beiträge". 
All other translations used the word "Beiträge", so I changed it for consistency.

Let me know if this is okay / useful!