### PR TITLE
🐛Fix disqus comment disappear

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -180,11 +180,11 @@
 	    }
 	  });
 
-		{{#if @custom.disqus_username}}
+		{{#if @custom.disqus_shortname}}
 			$('.post-comments').css({
 				'display': 'block'
 			});
-			var disqus = '{{@custom.disqus_username}}';
+			var disqus = '{{@custom.disqus_shortname}}';
 	    $('#show-disqus').on('click', function() {
 	      $.ajax({
 	        type: "GET",


### PR DESCRIPTION
Fixed disqus comment block disappear since the variable `disqus_username` was different from `disqus_shortname` in the theme option. 